### PR TITLE
Potential fix for code scanning alert no. 1: Disabled Spring CSRF protection

### DIFF
--- a/webApp-backend/src/main/java/org/ApeBodima/webApp_backend/config/security/SecurityConfig.java
+++ b/webApp-backend/src/main/java/org/ApeBodima/webApp_backend/config/security/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig{
                 )
                 .authenticationProvider(authenticationProvider())
                 .httpBasic(withDefaults())
-                .csrf(AbstractHttpConfigurer::disable);//TODO enable csrf tokens in request header
+                .csrf(withDefaults()); // Enable CSRF protection
         return http.build();
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/UdayaShantha/ApeBodima/security/code-scanning/1](https://github.com/UdayaShantha/ApeBodima/security/code-scanning/1)

To fix the problem, we need to enable CSRF protection in the `SecurityConfig` class. This can be done by removing the line that disables CSRF protection and ensuring that CSRF tokens are included in the request headers. This change should be made in the `securityFilterChain` method of the `SecurityConfig` class.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
